### PR TITLE
some systems include a space

### DIFF
--- a/check_iftraffic_nrpe.pl
+++ b/check_iftraffic_nrpe.pl
@@ -94,10 +94,10 @@ foreach (@f) {
         }
 }
 
-$line =~ s/\s+/ /g;
-@splitLine=split (/ /,$line);
+$line =~ s/^\s+|\s+$//g;
+@splitLine=split /[: ]+/, $line;
 
-(undef,$in_bytes)=split (/:/,$splitLine[1]);
+$in_bytes=$splitLine[1];
 $out_bytes=$splitLine[9];
 
 


### PR DESCRIPTION
We had an extra space between the interface with colon and the received bytes in /proc/net/dev
